### PR TITLE
xsm: add send_irq for dom0 and stubdom -> hvm guests

### DIFF
--- a/policy/modules/xen/stubdom.if
+++ b/policy/modules/xen/stubdom.if
@@ -89,7 +89,7 @@ interface(`stubdom_ioemu',`
 	allow stubdom_t $1:resource { add remove };
 	allow stubdom_t $1:domain { set_target shutdown settime };
 	allow stubdom_t $1:hvm { cacheattr getparam irqlevel pcilevel pciroute
-				 setparam trackdirtyvram hvmctl };
+				 setparam trackdirtyvram hvmctl send_irq };
 	allow stubdom_t $1:mmu { adjust physmap map_read map_write };
 	allow stubdom_t $1:grant copy;
 	allow $1 stubdom_t:grant { copy };

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -88,7 +88,7 @@ allow dom0_type xen_t:xen { kexec readapic writeapic mtrr_read mtrr_add mtrr_del
 
 # dom0 access to hvm guests
 allow dom0_type hvm_type:hvm { cacheattr getparam irqlevel pcilevel pciroute
-                               nested setparam hvmctl trackdirtyvram };
+                               nested setparam hvmctl trackdirtyvram send_irq };
 
 ########################################
 #


### PR DESCRIPTION
Added upstream @ f53e1bf04b43e1f9213cd6850167b26485941421
for device_model().  Denial can be reproduced by creating
a guest with HDA sound.

OXT-293

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
