### PR TITLE
xsm-policy: Fix compatibility with Xen 4.6.1

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -3,12 +3,13 @@
 #
 # class class_name { permission_name ... }
 
-# Class xen consists of dom0-only operations dealing with the hypervisor itself.
-# Unless otherwise specified, the source is the domain executing the hypercall,
-# and the target is the xen initial sid (type xen_t).
+# Class xen and xen2 consists of dom0-only operations dealing with the
+# hypervisor itself. Unless otherwise specified, the source is the domain
+# executing the hypercall, and the target is the xen initial sid (type xen_t).
 class xen
 {
-# XENPF_settime
+# XENPF_settime32
+# XENPF_settime64
     settime
 # XEN_SYSCTL_tbuf_op
     tbufcontrol
@@ -26,7 +27,8 @@ class xen
     mtrr_read
 # XENPF_microcode_update
     microcode
-# XEN_SYSCTL_physinfo, XEN_SYSCTL_topologyinfo, XEN_SYSCTL_numainfo
+# XEN_SYSCTL_physinfo, XEN_SYSCTL_cputopoinfo, XEN_SYSCTL_numainfo
+# XEN_SYSCTL_pcitopoinfo
     physinfo
 # XENPF_platform_quirk
     quirk
@@ -67,12 +69,30 @@ class xen
     cpupool_op
 # tmem hypercall (any access)
     tmem_op
-# TMEM_CONTROL command of tmem hypercall
+# XEN_SYSCTL_tmem_op command of tmem (part of sysctl)
     tmem_control
 # XEN_SYSCTL_scheduler_op with XEN_DOMCTL_SCHEDOP_getinfo, XEN_SYSCTL_sched_id
     getscheduler
 # XEN_SYSCTL_scheduler_op with XEN_DOMCTL_SCHEDOP_putinfo
     setscheduler
+}
+
+# This is a continuation of class xen, since only 32 permissions can be
+# defined per class
+class xen2
+{
+# XENPF_resource_op
+    resource_op
+# XEN_SYSCTL_psr_cmt_op
+    psr_cmt_op
+# XEN_SYSCTL_psr_cat_op
+    psr_cat_op
+# XENPF_get_symbol
+    get_symbol
+# PMU control
+    pmu_ctrl
+# PMU use (domains, including unprivileged ones, will be using this operation)
+    pmu_use
 }
 
 # Classes domain and domain2 consist of operations that a domain performs on
@@ -92,7 +112,7 @@ class domain
     unpause
 # XEN_DOMCTL_resumedomain
     resume
-# XEN_DOMCTL_createdomain
+# XEN_DOMCTL_arm_createdomain
     create
 # checked in FLASK_RELABEL_DOMAIN for any relabel operation:
 #  source = the old label of the domain
@@ -141,8 +161,10 @@ class domain
 # XEN_DOMCTL_sendtrigger
     trigger
 # XEN_DOMCTL_get_ext_vcpucontext
+# XEN_DOMCTL_set_vcpu_msrs
     getextvcpucontext
 # XEN_DOMCTL_set_ext_vcpucontext
+# XEN_DOMCTL_get_vcpu_msrs
     setextvcpucontext
 # XEN_DOMCTL_getvcpuextstate
     getvcpuextstate
@@ -196,16 +218,30 @@ class domain2
     setclaim
 # XEN_DOMCTL_setcorespersocket
     setcorespersocket
-# XEN_DOMCTL_setbiosuuid
-    setbiosuuid
-# XEN_DOMCTL_set_xcisrv
-    set_xcisrv
-# XEN_DOMCTL_aperture_map
-    aperture_map
-# XEN_DOMCTL_iommu_x_mapping
-    iommu_x_mapping
-# XEN_DOMCTL_iommu_map_batch
-    iommu_map_batch
+# XEN_DOMCTL_set_max_evtchn
+    set_max_evtchn
+# XEN_DOMCTL_cacheflush
+    cacheflush
+# Creation of the hardware domain when it is not dom0
+    create_hardware_domain
+# XEN_DOMCTL_setvnumainfo
+    set_vnumainfo
+# XENMEM_getvnumainfo
+    get_vnumainfo
+# XEN_DOMCTL_psr_cmt_op
+    psr_cmt_op
+# XEN_DOMCTL_set_access_required
+# XEN_DOMCTL_monitor_op
+# XEN_DOMCTL_vm_event_op
+    vm_event
+# XENMEM_access_op
+    mem_access
+# XENMEM_paging_op
+    mem_paging
+# XENMEM_sharing_op
+    mem_sharing
+# XEN_DOMCTL_psr_cat_op
+    psr_cat_op
 }
 
 # Similar to class domain, but primarily contains domctls related to HVM domains
@@ -234,8 +270,6 @@ class hvm
 # HVMOP_set_mem_access, HVMOP_get_mem_access, HVMOP_pagetable_dying,
 # HVMOP_inject_trap
     hvmctl
-# XEN_DOMCTL_set_access_required
-    mem_event
 # XEN_DOMCTL_mem_sharing_op and XENMEM_sharing_op_{share,add_physmap} with:
 #  source = the domain making the hypercall
 #  target = domain whose memory is being shared
@@ -250,6 +284,13 @@ class hvm
     share_mem
 # HVMOP_set_param setting HVM_PARAM_NESTEDHVM
     nested
+# HVMOP_set_param setting HVM_PARAM_ALTP2MHVM
+    altp2mhvm
+# HVMOP_altp2m_set_domain_state HVMOP_altp2m_get_domain_state
+# HVMOP_altp2m_vcpu_enable_notify HVMOP_altp2m_create_p2m
+# HVMOP_altp2m_destroy_p2m HVMOP_altp2m_switch_p2m
+# HVMOP_altp2m_set_mem_access HVMOP_altp2m_change_gfn
+    altp2mhvm_op
 }
 
 # Class event describes event channels.  Interdomain event channels have their
@@ -317,7 +358,7 @@ class mmu
 #  source = domain making the hypercall
 #  target = domain whose pages are being mapped
     map_write
-# XEN_DOMCTL_getpageframeinfo*
+# XEN_DOMCTL_getpageframeinfo3
     pageinfo
 # XEN_DOMCTL_getmemlist
     pagelist
@@ -403,7 +444,7 @@ class resource
     remove_iomem
 # XEN_DOMCTL_get_device_group, XEN_DOMCTL_test_assign_device:
 #  source = domain making the hypercall
-#  target = PCI device being queried
+#  target = device being queried
     stat_device
 # XEN_DOMCTL_assign_device
     add_device

--- a/policy/flask/initial_sids
+++ b/policy/flask/initial_sids
@@ -13,4 +13,6 @@ sid ioport
 sid iomem
 sid irq
 sid device
+sid domU
+sid domDM
 # FLASK

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -8,6 +8,7 @@
 # for userspace object managers
 
 class xen
+class xen2
 class domain
 class domain2
 class hvm

--- a/policy/modules/xen/dom0.te
+++ b/policy/modules/xen/dom0.te
@@ -41,7 +41,7 @@ allow dom0_t self:mmu { pinpage map_read map_write adjust updatemp stat exchange
 allow dom0_t self:grant { query setup };
 allow dom0_t self:domain { getscheduler getdomaininfo getvcpuinfo
                            getaffinity };
-allow dom0_t self:domain2 { setscheduler iommu_map_batch iommu_x_mapping aperture_map };
+allow dom0_t self:domain2 { setscheduler };
 
 allow dom0_t self:event { bind create };
 allow dom0_t self:resource { add remove setup };

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -42,7 +42,7 @@ interface(`xen_domain_type',`
 				setvcpucontext getscheduler pause unpause 
 				getvcpuinfo getvcpuextstate getaddrsize getaffinity settime
 				setdomainhandle shutdown set_misc_info };
-	allow dom0_type $1:domain2 {setcorespersocket setscheduler set_xcisrv set_cpuid set_as_target iommu_x_mapping iommu_map_batch aperture_map };
+	allow dom0_type $1:domain2 {setcorespersocket setscheduler set_cpuid set_as_target };
 			
 	allow dom0_type $1:shadow {enable};
 	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op};

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -49,6 +49,8 @@ sid irq gen_context(system_u:object_r:pirq_t,s0)
 sid iomem gen_context(system_u:object_r:iomem_t,s0)
 sid ioport gen_context(system_u:object_r:ioport_t,s0)
 sid device gen_context(system_u:object_r:device_t,s0)
+sid domU gen_context(system_u:system_r:hvm_guest_t,s0)
+sid domDM gen_context(system_u:system_r:stubdom_t,s0)
 
 role system_r;
 role user_r;


### PR DESCRIPTION
Xen 4.6.1 fails to initialize Flask with the following error:
(XEN) XSM Framework v1.0.0 initialized
(XEN) Policy len 0x2a09, start at ffff83041e7fd000.
(XEN) Flask: 128 avtab hash slots, 299 rules.
(XEN) Flask: 128 avtab hash slots, 299 rules.
(XEN) Flask:  3 users, 5 roles, 56 types, 0 bools
(XEN) Flask:  11 classes, 299 rules
(XEN) Flask:  class 2 is incorrect, found domain but should be xen2
(XEN) Flask:  the definition of a class is incorrect
(XEN) Flask:  Access controls disabled until policy is loaded.

This is due to an inconsistency between the Flask policy definitions
in the xen-4.6.1 source tree and those defined by this policy.

Synchronize the Flask definition files in the OpenXT XSM/Flask policy
with the upstream definitions in Xen 4.6.1. In the future, we should
dispense with maintaining a separate copy of these files and just pull
the files from the xen source tree (xen/xsm/flask/policy in the
xen source tree).

The changes to the Flask definition files also require corresponding
updates to several of the policy files.  We need to define security
contexts for the new initial SIDs, although these will not truly be
used until we switch to using libxl.  We must remove any references
to permissions that are no longer defined by Flask.

A number of new permissions were added to Xen that are not currently
being allowed by this policy; we will have to test and assess which
ones ought to be allowed and where.  We can look at the upstream
Flask example policy (under tools/flask/policy/policy in the xen
source tree) for reference and should probably import the latest
xen.if macros from it for use in this policy.

After this change, we get:
(XEN) XSM Framework v1.0.0 initialized
(XEN) Policy len 0x2b61, start at ffff83043edfd000.
(XEN) Flask: 128 avtab hash slots, 299 rules.
(XEN) Flask: 128 avtab hash slots, 299 rules.
(XEN) Flask:  3 users, 5 roles, 56 types, 0 bools
(XEN) Flask:  12 classes, 299 rules
(XEN) Flask:  Starting in enforcing mode.

I do see one avc denial upon creating a guest but it does not
seem to be fatal, so I am deferring dealing with it until
a later change.

OXT-726

Signed-off-by: Stephen Smalley sds@tycho.nsa.gov
