### PR TITLE
xsm-policy: allow hvm guests to invoke XENMEM_get_vnumainfo hypercall

### DIFF
--- a/policy/modules/xen/guesthvm.te
+++ b/policy/modules/xen/guesthvm.te
@@ -74,6 +74,7 @@ nilfvm_event_src(hvm_guest_t, nilfvm-hvm_guest_evchn_t)
 allow hvm_guest_t self:mmu physmap;
 allow hvm_guest_t self:grant copy;
 allow hvm_guest_t self:resource remove;
+allow hvm_guest_t self:domain2 get_vnumainfo;
 
 ndvm_use(hvm_guest_t)
 nilfvm_use(hvm_guest_t)

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -71,6 +71,8 @@ allow xen_t iomem_t:resource { add_iomem remove_iomem };
 allow xen_t pirq_t:resource { add_irq remove_irq };
 allow xen_t { ndvm_t hvm_guest_t stubdom_t }:resource remove;
 
+device_remove_resource(xen_t)
+
 syncvm_remove_resource(xen_t)
 
 ########################################


### PR DESCRIPTION
Xen 4.6 introduced the use of the XENMEM_get_vnumainfo hypercall by
HVM guests.  Allow this within the same domain type.  In the future,
we should rebase OpenXT xsm-policy on the policy in the upstream Xen
tree and reuse its concept of self types to distinguish intra-domain
access from inter-domain with same domain type access.

Addresses XSM/Flask denials of the form:
  avc:  denied  { get_vnumainfo } for domid=3 scontext=system_u:system_r:hvm_guest_t tcontext=system_u:system_r:hvm_guest_t tclass=domain2

OXT-784

Signed-off-by: Stephen Smalley sds@tycho.nsa.gov
