### PR TITLE
xsm-policy: Address denials triggered by libxl.

### DIFF
--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -40,12 +40,14 @@ interface(`xen_domain_type',`
 	allow dom0_type $1:domain {create destroy max_vcpus setdomainmaxmem 
 				setaddrsize getdomaininfo hypercall 
 				setvcpucontext getscheduler pause unpause 
-				getvcpuinfo getvcpuextstate getaddrsize getaffinity settime
-				setdomainhandle shutdown set_misc_info };
-	allow dom0_type $1:domain2 {setcorespersocket setscheduler set_cpuid set_as_target };
+				getvcpuinfo getvcpuextstate getaddrsize
+				setaffinity getaffinity settime
+				setdomainhandle shutdown set_misc_info trigger};
+	allow dom0_type $1:domain2 {setcorespersocket setscheduler set_cpuid
+				   set_as_target set_max_evtchn settsc};
 			
 	allow dom0_type $1:shadow {enable};
-	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op};
+	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op stat };
 	allow dom0_type $1:resource { add remove };
 	allow $1 $1:mmu {map_read map_write adjust pinpage};
 	allow $1 domio_t:mmu {map_read};

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -88,11 +88,13 @@ allow xen_t dom0_type:resource { add remove };
 allow dom0_type xen_t:mmu { memorymap };
 allow dom0_type xen_t:xen { kexec readapic writeapic mtrr_read mtrr_add mtrr_del 
                          getscheduler setscheduler physinfo heap quirk
-                         settime microcode firmware sleep getcpuinfo pm_op };
+                         settime microcode firmware sleep getcpuinfo pm_op
+			 cpupool_op };
 
 # dom0 access to hvm guests
 allow dom0_type hvm_type:hvm { cacheattr getparam irqlevel pcilevel pciroute
-                               nested setparam hvmctl trackdirtyvram send_irq };
+                               nested setparam hvmctl trackdirtyvram send_irq
+			       altp2mhvm };
 
 ########################################
 #


### PR DESCRIPTION
Address the following denials:

avc:  denied  { cpupool_op } for domid=0 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:xen_t tclass=xen

avc:  denied  { setaffinity } for domid=0 target=1 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:ndvm_t tclass=domain

avc:  denied  { settsc } for domid=0 target=1 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:ndvm_t tclass=domain2

avc:  denied  { set_max_evtchn } for domid=0 target=1 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:ndvm_t tclass=domain2

avc:  denied  { setaffinity } for domid=0 target=2 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:uivm_t tclass=domain

avc:  denied  { settsc } for domid=0 target=2 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:uivm_t tclass=domain2

avc:  denied  { set_max_evtchn } for domid=0 target=2 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:uivm_t tclass=domain2

avc:  denied  { setaffinity } for domid=0 target=3 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:hvm_guest_t tclass=domain

avc:  denied  { altp2mhvm } for domid=0 target=3 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:hvm_guest_t tclass=hvm

avc: denied  { settsc } for domid=0 target=3 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:hvm_guest_t tclass=domain2

avc:  denied  { stat } for domid=0 target=3 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:hvm_guest_t tclass=mmu

avc:  denied  { set_max_evtchn } for domid=0 target=3 scontext=system_u:system_r:dom0_t tcontext=system_u:system_r:hvm_guest_t tclass=domain2

OXT-459

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>