### PR TITLE
OXT-826 : Policy for device passthrough to NDVM with and without IOMMU

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -430,6 +430,12 @@ class resource
 #  target = resource's security label
 # also checked when using some core Xen devices (target xen_t)
     use
+# IOMMU required before a resource will be added to a domain:
+# checked when adding a resource to a domain:
+#  source = domain which will have access to the resource
+#  target = resource's security label
+# also checked when using some core Xen devices (target xen_t)
+    use_with_iommu
 # PHYSDEVOP_map_pirq and ioapic writes for dom0, when acting on real IRQs
 #  For GSI interrupts, the IRQ's label is indexed by the IRQ number
 #  For MSI interrupts, the label of the PCI device is used
@@ -460,6 +466,15 @@ class resource
 # checked for PHYSDEVOP_setup_gsi (target IRQ)
 # checked for PHYSDEVOP_pci_mmcfg_reserved (target xen_t)
     setup
+}
+
+# Class IOMMU governs whether a weak IOMMU is tolerable
+class iommu
+{
+# Allow use of an insecure IOMMU to grant resouces to domains that
+# require an IOMMU.
+# Provided to enable support with administrator consent for older hardware.
+    use_insecure
 }
 
 # Class security describes the FLASK security server itself; these operations

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -19,5 +19,6 @@ class event
 class grant
 class security
 class v4v
+class iommu
 
 # FLASK

--- a/policy/modules/xen/ndvm.te
+++ b/policy/modules/xen/ndvm.te
@@ -40,14 +40,14 @@ dom0_event_src(ndvm_t, dom0-ndvm_evchn_t)
 # Local Policy
 #
 
-dom0_pt_guest(ndvm_t)
+dom0_pt_guest_with_iommu(ndvm_t)
 dom0_send_v4v(ndvm_t)
 domio_map_write_mmu(ndvm_t)
-ioport_use_resource(ndvm_t)
+ioport_use_resource_with_iommu(ndvm_t)
 iomem_map_rw_mmu(ndvm_t)
-iomem_use_resource(ndvm_t)
+iomem_use_resource_with_iommu(ndvm_t)
 pirq_remove_resource(ndvm_t)
-pirq_use_resource(ndvm_t)
+pirq_use_resource_with_iommu(ndvm_t)
 syncvm_remove_resource(ndvm_t)
 uivm_send_v4v(ndvm_t)
 xen_write_console(ndvm_t)

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -70,7 +70,25 @@ interface(`ioport_use_resource',`
 		type ioport_t;
 	')
 
-	allow $1 ioport_t:resource use;
+	allow $1 ioport_t:resource { use use_with_iommu };
+')
+########################################
+## <summary>
+##	Allow the specified type to use
+##	ioport resources only if IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`ioport_use_resource_with_iommu',`
+	gen_require(`
+		type ioport_t;
+	')
+
+	allow $1 ioport_t:resource use_with_iommu;
 ')
 ########################################
 ## <summary>
@@ -124,7 +142,25 @@ interface(`pirq_use_resource',`
 		type pirq_t;
 	')
 
-	allow $1 pirq_t:resource use;
+	allow $1 pirq_t:resource { use use_with_iommu };
+')
+########################################
+## <summary>
+##	Allow the specified type to use
+##	pirq resources only if IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`pirq_use_resource_with_iommu',`
+	gen_require(`
+		type pirq_t;
+	')
+
+	allow $1 pirq_t:resource use_with_iommu;
 ')
 ########################################
 ## <summary>
@@ -324,7 +360,25 @@ interface(`domio_use_resource',`
 		type domio_t;
 	')
 
-	allow $1 domio_t:resource use;
+	allow $1 domio_t:resource { use use_with_iommu };
+')
+########################################
+## <summary>
+##	Allow the specified type to
+##	use domio resources only if IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`domio_use_resource_with_iommu',`
+	gen_require(`
+		type domio_t;
+	')
+
+	allow $1 domio_t:resource use_with_iommu;
 ')
 ########################################
 ## <summary>
@@ -342,7 +396,25 @@ interface(`iomem_use_resource',`
 		type iomem_t;
 	')
 
-	allow $1 iomem_t:resource use;
+	allow $1 iomem_t:resource { use use_with_iommu};
+')
+########################################
+## <summary>
+##	Allow the specified type to
+##	use iomem resources only if IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`iomem_use_resource_with_iommu',`
+	gen_require(`
+		type iomem_t;
+	')
+
+	allow $1 iomem_t:resource use_with_iommu;
 ')
 ########################################
 ## <summary>
@@ -360,7 +432,25 @@ interface(`device_use_resource',`
 		type device_t;
 	')
 
-	allow $1 device_t:resource use;
+	allow $1 device_t:resource { use use_with_iommu };
+')
+########################################
+## <summary>
+##	Allow the specified type to
+##	use device resources only if IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`device_use_resource_with_iommu',`
+	gen_require(`
+		type device_t;
+	')
+
+	allow $1 device_t:resource use_with_iommu;
 ')
 ########################################
 ## <summary>
@@ -539,10 +629,31 @@ interface(`dom0_pt_guest',`
 		type pirq_t, device_t, iomem_t, ioport_t;
 	')
 
-	allow $1 pirq_t:resource use;
-	allow $1 device_t:resource use;
-	allow $1 iomem_t:resource use;
-	allow $1 ioport_t:resource use;
+    pirq_use_resource($1)
+    device_use_resource($1)
+    iomem_use_resource($1)
+    ioport_use_resource($1)
+')
+########################################
+## <summary>
+##	Allow dom0 to pass through PCI devices
+##	to the specified guest.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`dom0_pt_guest_with_iommu',`
+	gen_require(`
+		type pirq_t, device_t, iomem_t, ioport_t;
+	')
+
+    pirq_use_resource_with_iommu($1)
+    device_use_resource_with_iommu($1)
+    iomem_use_resource_with_iommu($1)
+    ioport_use_resource_with_iommu($1)
 ')
 ########################################
 ## <summary>
@@ -582,7 +693,31 @@ interface(`use_device',`
 		type domio_t;
 	')
 
-	allow $1 $2:resource use;
+	allow $1 $2:resource { use use_with_iommu };
+	allow $1 domio_t:mmu { map_read map_write };
+')
+########################################
+## <summary>
+##	Allow a device to be used by a domain
+##  only if an IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain.
+##	</summary>
+## </param>
+## <param name="type">
+##	<summary>
+##	Type of the device.
+##	</summary>
+## </param>
+#
+interface(`use_device_with_iommu',`
+	gen_require(`
+		type domio_t;
+	')
+
+	allow $1 $2:resource use_with_iommu;
 	allow $1 domio_t:mmu { map_read map_write };
 ')
 ########################################
@@ -601,6 +736,24 @@ interface(`iomem_use_device',`
 	')
 
 	use_device($1, iomem_t)
+')
+########################################
+## <summary>
+##	Allow a domain to use the iomem device
+##  only if an IOMMU provides isolation.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain.
+##	</summary>
+## </param>
+#
+interface(`iomem_use_device_with_iommu',`
+	gen_require(`
+		type iomem_t;
+	')
+
+	use_device_with_iommu($1, iomem_t)
 ')
 ########################################
 ## <summary>

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -96,6 +96,13 @@ allow dom0_type hvm_type:hvm { cacheattr getparam irqlevel pcilevel pciroute
                                nested setparam hvmctl trackdirtyvram send_irq
 			       altp2mhvm };
 
+# Choice: VM isolation vs. compatibility with older hardware:
+# dom0 permission to use an insecure IOMMU
+# with VMs with XSM policy that requires an IOMMU before allowing device access.
+# The more secure choice is NOT to allow "use_insecure" but prevents
+# compatibility with older machines incapable of interrupt remapping.
+allow dom0_type xen_t:iommu { use_insecure };
+
 ########################################
 #
 #  HVM attribute


### PR DESCRIPTION
[ PR for initial @dpsmith review ]

Policy as per this PR will only allow PCI device passthrough to the NDVM when an IOMMU is present. This policy allows passthough on older hardware with a less strict IOMMU.

Tested on both a Dell OptiPlex 980 and 9020: NDVM will not start when VT-d is disabled but the host otherwise boots to an accessible UIVM with platform networking disabled. VT-d enabled boots with NDVM and functioning networking.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>