### PR TITLE
[Xen 4.9] Update XSM policy for Xen 4.9

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -93,6 +93,14 @@ class xen2
     pmu_ctrl
 # PMU use (domains, including unprivileged ones, will be using this operation)
     pmu_use
+# XEN_SYSCTL_get_cpu_levelling_caps
+    get_cpu_levelling_caps
+# XEN_SYSCTL_get_cpu_featureset
+    get_cpu_featureset
+# XEN_SYSCTL_livepatch_op
+    livepatch_op
+# XEN_SYSCTL_gcov_op
+    gcov_op
 }
 
 # Classes domain and domain2 consist of operations that a domain performs on
@@ -105,6 +113,9 @@ class xen2
 class domain
 {
 # XEN_DOMCTL_setvcpucontext
+# XEN_DOMCTL_setvcpuextstate
+# XEN_DOMCTL_set_ext_vcpucontext
+# XEN_DOMCTL_set_vcpu_msrs
     setvcpucontext
 # XEN_DOMCTL_pausedomain
     pause
@@ -136,6 +147,9 @@ class domain
 # XEN_DOMCTL_getvcpuinfo
     getvcpuinfo
 # XEN_DOMCTL_getvcpucontext
+# XEN_DOMCTL_get_ext_vcpucontext
+# XEN_DOMCTL_getvcpuextstate
+# XEN_DOMCTL_get_vcpu_msrs
     getvcpucontext
 # XEN_DOMCTL_max_mem
     setdomainmaxmem
@@ -160,16 +174,6 @@ class domain
     getaddrsize
 # XEN_DOMCTL_sendtrigger
     trigger
-# XEN_DOMCTL_get_ext_vcpucontext
-# XEN_DOMCTL_set_vcpu_msrs
-    getextvcpucontext
-# XEN_DOMCTL_set_ext_vcpucontext
-# XEN_DOMCTL_get_vcpu_msrs
-    setextvcpucontext
-# XEN_DOMCTL_getvcpuextstate
-    getvcpuextstate
-# XEN_DOMCTL_setvcpuextstate
-    setvcpuextstate
 # XENMEM_get_pod_target
     getpodtarget
 # XENMEM_set_pod_target
@@ -216,8 +220,6 @@ class domain2
     setscheduler
 # XENMEM_claim_pages
     setclaim
-# XEN_DOMCTL_setcorespersocket
-    setcorespersocket
 # XEN_DOMCTL_set_max_evtchn
     set_max_evtchn
 # XEN_DOMCTL_cacheflush
@@ -234,6 +236,8 @@ class domain2
 # XEN_DOMCTL_monitor_op
 # XEN_DOMCTL_vm_event_op
     vm_event
+# XEN_DOMCTL_soft_reset
+    soft_reset
 # XENMEM_access_op
     mem_access
 # XENMEM_paging_op
@@ -242,6 +246,8 @@ class domain2
     mem_sharing
 # XEN_DOMCTL_psr_cat_op
     psr_cat_op
+# XEN_DOMCTL_setcorespersocket
+    setcorespersocket
 }
 
 # Similar to class domain, but primarily contains domctls related to HVM domains
@@ -255,20 +261,11 @@ class hvm
     setparam
 # HVMOP_get_param
     getparam
-# HVMOP_set_pci_intx_level (also needs hvmctl)
-    pcilevel
-# HVMOP_set_isa_irq_level
-    irqlevel
-# HVMOP_set_pci_link_route
-    pciroute
     bind_irq
 # XEN_DOMCTL_pin_mem_cacheattr
     cacheattr
-# HVMOP_track_dirty_vram
-    trackdirtyvram
-# HVMOP_modified_memory, HVMOP_get_mem_type, HVMOP_set_mem_type,
-# HVMOP_set_mem_access, HVMOP_get_mem_access, HVMOP_pagetable_dying,
-# HVMOP_inject_trap
+# HVMOP_get_mem_type,
+# HVMOP_set_mem_access, HVMOP_get_mem_access, HVMOP_pagetable_dying
     hvmctl
 # XEN_DOMCTL_mem_sharing_op and XENMEM_sharing_op_{share,add_physmap} with:
 #  source = the domain making the hypercall
@@ -276,8 +273,6 @@ class hvm
     mem_sharing
 # XEN_DOMCTL_audit_p2m
     audit_p2m
-# HVMOP_inject_msi
-    send_irq
 # checked in XENMEM_sharing_op_{share,add_physmap} with:
 #  source = domain whose memory is being shared
 #  target = client domain
@@ -291,6 +286,8 @@ class hvm
 # HVMOP_altp2m_destroy_p2m HVMOP_altp2m_switch_p2m
 # HVMOP_altp2m_set_mem_access HVMOP_altp2m_change_gfn
     altp2mhvm_op
+# DMOP
+    dm
 }
 
 # Class event describes event channels.  Interdomain event channels have their
@@ -498,8 +495,6 @@ class security
     load_policy
 # use the security server to compute an object relabel
     compute_relabel
-# use the security server to list the SIDs reachable by a given user
-    compute_user
 # allow switching between enforcing and permissive mode
     setenforce
 # allow changing policy booleans
@@ -510,6 +505,33 @@ class security
     add_ocontext
 # remove ocontext label definitions for resources
     del_ocontext
+}
+
+# Class version is used to describe the XENVER_ hypercall.
+# Almost all sub-ops are described here - in the default case all of them should
+# be allowed except the XENVER_commandline.
+#
+# The ones that are omitted are XENVER_version, XENVER_platform_parameters,
+# and XENVER_get_features  - as they MUST always be returned to a guest.
+#
+class version
+{
+# Extra informations (-unstable).
+    xen_extraversion
+# Compile information of the hypervisor.
+    xen_compile_info
+# Such as "xen-3.0-x86_64 xen-3.0-x86_32p hvm-3.0-x86_32 hvm-3.0-x86_32p hvm-3.0-x86_64".
+    xen_capabilities
+# Source code changeset.
+    xen_changeset
+# Page size the hypervisor uses.
+    xen_pagesize
+# An value that the control stack can choose.
+    xen_guest_handle
+# Xen command line.
+    xen_commandline
+# Xen build id
+    xen_build_id
 }
 
 class v4v

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -18,6 +18,7 @@ class shadow
 class event
 class grant
 class security
+class version
 class v4v
 
 # FLASK

--- a/policy/modules/xen/guesthvm.te
+++ b/policy/modules/xen/guesthvm.te
@@ -75,6 +75,7 @@ allow hvm_guest_t self:mmu physmap;
 allow hvm_guest_t self:grant copy;
 allow hvm_guest_t self:resource remove;
 allow hvm_guest_t self:domain2 get_vnumainfo;
+allow hvm_guest_t xen_t:version xen_guest_handle;
 
 ndvm_use(hvm_guest_t)
 nilfvm_use(hvm_guest_t)

--- a/policy/modules/xen/stubdom.if
+++ b/policy/modules/xen/stubdom.if
@@ -88,8 +88,8 @@ interface(`stubdom_ioemu',`
 
 	allow stubdom_t $1:resource { add remove };
 	allow stubdom_t $1:domain { getdomaininfo set_target shutdown settime };
-	allow stubdom_t $1:hvm { cacheattr getparam irqlevel pcilevel pciroute
-				 setparam trackdirtyvram hvmctl send_irq };
+	allow stubdom_t $1:hvm { cacheattr getparam
+				 setparam hvmctl };
 	allow stubdom_t $1:mmu { adjust physmap map_read map_write };
 	allow stubdom_t $1:grant copy;
 	allow $1 stubdom_t:grant { copy };

--- a/policy/modules/xen/stubdom.if
+++ b/policy/modules/xen/stubdom.if
@@ -88,7 +88,7 @@ interface(`stubdom_ioemu',`
 
 	allow stubdom_t $1:resource { add remove };
 	allow stubdom_t $1:domain { getdomaininfo set_target shutdown settime };
-	allow stubdom_t $1:hvm { cacheattr getparam
+	allow stubdom_t $1:hvm { cacheattr getparam dm
 				 setparam hvmctl };
 	allow stubdom_t $1:mmu { adjust physmap map_read map_write };
 	allow stubdom_t $1:grant copy;

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -40,7 +40,7 @@ interface(`xen_domain_type',`
 	allow dom0_type $1:domain {create destroy max_vcpus setdomainmaxmem 
 				setaddrsize getdomaininfo hypercall 
 				setvcpucontext getscheduler pause unpause 
-				getvcpuinfo getvcpuextstate getaddrsize
+				getvcpuinfo getaddrsize
 				setaffinity getaffinity settime
 				setdomainhandle shutdown set_misc_info trigger};
 	allow dom0_type $1:domain2 {setcorespersocket setscheduler set_cpuid

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -49,10 +49,12 @@ interface(`xen_domain_type',`
 	allow dom0_type $1:shadow {enable};
 	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op stat };
 	allow dom0_type $1:resource { add remove };
+	allow dom0_type $1:domain { getvcpucontext };
 	allow $1 $1:mmu {map_read map_write adjust pinpage};
 	allow $1 domio_t:mmu {map_read};
 	allow $1 $1:grant {query setup};
 	allow dom0_type $1:grant { copy map_read unmap query setup };
+    allow $1 xen_t:version { xen_extraversion };
 ')
 ########################################
 ## <summary>

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -92,8 +92,8 @@ allow dom0_type xen_t:xen { kexec readapic writeapic mtrr_read mtrr_add mtrr_del
 			 cpupool_op };
 
 # dom0 access to hvm guests
-allow dom0_type hvm_type:hvm { cacheattr getparam irqlevel pcilevel pciroute
-                               nested setparam hvmctl trackdirtyvram send_irq
+allow dom0_type hvm_type:hvm { cacheattr getparam
+                               nested setparam hvmctl
 			       altp2mhvm };
 
 ########################################

--- a/policy/modules/xen/xen.te
+++ b/policy/modules/xen/xen.te
@@ -90,11 +90,15 @@ allow dom0_type xen_t:xen { kexec readapic writeapic mtrr_read mtrr_add mtrr_del
                          getscheduler setscheduler physinfo heap quirk
                          settime microcode firmware sleep getcpuinfo pm_op
 			 cpupool_op };
+allow dom0_type xen_t:version { xen_compile_info xen_capabilities
+                                xen_changeset xen_pagesize
+                                xen_commandline xen_build_id
+                                xen_extraversion };
 
 # dom0 access to hvm guests
 allow dom0_type hvm_type:hvm { cacheattr getparam
                                nested setparam hvmctl
-			       altp2mhvm };
+                               altp2mhvm gethvmc sethvmc };
 
 ########################################
 #


### PR DESCRIPTION
caveat: This update to the XSM policy has been performed with the aim of getting a functioning OpenXT system with XSM enforcing with Xen 4.9. The security properties of the changes here have not been studied in detail and should be reviewed carefully before acceptance.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>