### PR TITLE
OXT-1327: HVM NDVM support

### DIFF
--- a/policy/modules/xen/guesthvm.te
+++ b/policy/modules/xen/guesthvm.te
@@ -71,12 +71,6 @@ nilfvm_event_src(hvm_guest_t, nilfvm-hvm_guest_evchn_t)
 # HVM Guest Local policy
 #
 
-allow hvm_guest_t self:mmu physmap;
-allow hvm_guest_t self:grant copy;
-allow hvm_guest_t self:resource remove;
-allow hvm_guest_t self:domain2 get_vnumainfo;
-allow hvm_guest_t xen_t:version xen_guest_handle;
-
 ndvm_use(hvm_guest_t)
 nilfvm_use(hvm_guest_t)
 dom0_copy_grant(hvm_guest_t)

--- a/policy/modules/xen/ndvm.te
+++ b/policy/modules/xen/ndvm.te
@@ -26,6 +26,7 @@ policy_module(ndvm, 0.2)
 type ndvm_t;
 xen_domain_type(ndvm_t)
 xen_pv_type(ndvm_t)
+xen_hvm_type(ndvm_t)
 
 type ndvm-dom0_evchn_t;
 xen_event_type(ndvm-dom0_evchn_t)

--- a/policy/modules/xen/ndvm.te
+++ b/policy/modules/xen/ndvm.te
@@ -35,6 +35,15 @@ type dom0-ndvm_evchn_t;
 xen_event_type(dom0-ndvm_evchn_t)
 dom0_event_src(ndvm_t, dom0-ndvm_evchn_t)
 
+#types for event channel between ndvm and stubdom
+type ndvm-stubdom_evchn_t;
+xen_event_type(ndvm-stubdom_evchn_t)
+stubdom_event_dst(ndvm_t, ndvm-stubdom_evchn_t)
+
+type stubdom-ndvm_evchn_t;
+xen_event_type(stubdom-ndvm_evchn_t)
+stubdom_event_src(ndvm_t, stubdom-ndvm_evchn_t)
+
 ########################################
 #
 # Local Policy
@@ -49,6 +58,7 @@ iomem_use_resource_iommu_nointremap(ndvm_t)
 pirq_remove_resource(ndvm_t)
 pirq_use_resource_iommu_nointremap(ndvm_t)
 syncvm_remove_resource(ndvm_t)
+stubdom_ioemu(ndvm_t)
 uivm_send_v4v(ndvm_t)
 xen_write_console(ndvm_t)
 dom0_map_write_grant(ndvm_t)

--- a/policy/modules/xen/stubdom.te
+++ b/policy/modules/xen/stubdom.te
@@ -35,14 +35,6 @@ type dom0-stubdom_evchn_t;
 xen_event_type(dom0-stubdom_evchn_t)
 dom0_event_src(stubdom_t, dom0-stubdom_evchn_t)
 
-type stubdom-ndvm_evchn_t;
-xen_event_type(stubdom-ndvm_evchn_t)
-ndvm_event_dst(stubdom_t, stubdom-ndvm_evchn_t)
-
-type ndvm-stubdom_evchn_t;
-xen_event_type(ndvm-stubdom_evchn_t)
-ndvm_event_src(stubdom_t, ndvm-stubdom_evchn_t)
-
 #types for event channel between stubdom and nilfvm
 type nilfvm-stubdom_evchn_t;
 xen_event_type(nilfvm-stubdom_evchn_t)

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -651,6 +651,12 @@ interface(`xen_hvm_type',`
                 attribute hvm_type;
 	')
 
+	allow $1 self:mmu physmap;
+	allow $1 self:grant copy;
+	allow $1 self:resource remove;
+	allow $1 self:domain2 get_vnumainfo;
+	allow $1 xen_t:version xen_guest_handle;
+
 	typeattribute $1 hvm_type;
 ')
 ########################################


### PR DESCRIPTION
This PR makes ndvm_t usable for both PV and HVM.  Distinct types could be used, but then all the ndvm_t communication channels would need to be duplicated.  The upstream Xen refpolicy makes domU usable as either PV or HVM.

HVM NDVM must use a stubdom.  Is this okay?  Otherwise, I think it's just a xsm-policy change to get it working.