### PR TITLE
[xsm] Add access to resource_map for HVM guests

### DIFF
--- a/policy/modules/xen/dom0.te
+++ b/policy/modules/xen/dom0.te
@@ -51,6 +51,7 @@ allow dom0_t evchn0-0_t:event send;
 
 allow dom0_t iomem_t:resource setup;
 allow dom0_t stubdom_t:domain2 make_priv_for;
+allow dom0_t hvm_guest_t:domain2 resource_map;
 
 allow dom0_t xen_t:resource setup;
 allow dom0_t xen_t:xen2 get_cpu_featureset;


### PR DESCRIPTION
Allow guests without a stubdom to initialize QEMU
in Xen 4.11.

OXT-1529

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>