### PR TITLE
S9: [flask] Update for Xen 4.12

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -222,8 +222,6 @@ class domain2
     setscheduler
 # XENMEM_claim_pages
     setclaim
-# XEN_DOMCTL_set_max_evtchn
-    set_max_evtchn
 # XEN_DOMCTL_cacheflush
     cacheflush
 # Creation of the hardware domain when it is not dom0
@@ -248,10 +246,10 @@ class domain2
     mem_sharing
 # XEN_DOMCTL_psr_alloc
     psr_alloc
-# XEN_DOMCTL_set_gnttab_limits
-    set_gnttab_limits
 # XENMEM_resource_map
     resource_map
+# XEN_DOMCTL_get_cpu_policy
+    get_cpu_policy
 }
 
 # Similar to class domain, but primarily contains domctls related to HVM domains
@@ -532,6 +530,22 @@ class version
     xen_commandline
 # Xen build id
     xen_build_id
+}
+
+# Class argo is used to describe the Argo interdomain communication system.
+class argo
+{
+    # Enable initialization of a domain's argo subsystem and
+    # permission to access the argo hypercall operations.
+    enable
+    # Domain requesting registration of a communication ring
+    # to receive messages from a specific other domain.
+    register_single_source
+    # Domain requesting registration of a communication ring
+    # to receive messages from any other domain.
+    register_any_source
+    # Domain sending a message to another domain.
+    send
 }
 
 class v4v

--- a/policy/flask/security_classes
+++ b/policy/flask/security_classes
@@ -19,6 +19,7 @@ class event
 class grant
 class security
 class version
+class argo
 class v4v
 
 # FLASK

--- a/policy/modules/xen/dom0.te
+++ b/policy/modules/xen/dom0.te
@@ -54,6 +54,7 @@ allow dom0_t stubdom_t:domain2 make_priv_for;
 allow dom0_t hvm_guest_t:domain2 resource_map;
 
 allow dom0_t xen_t:resource setup;
+allow dom0_t xen_t:xen mca_op;
 allow dom0_t xen_t:xen2 get_cpu_featureset;
 
 domio_map_rw_mmu(dom0_t)
@@ -63,25 +64,25 @@ ndvm_manage_resource(dom0_t)
 ndvm_send_v4v(dom0_t)
 ndvm_use(dom0_t)
 ndvm_map_write_grant(dom0_t)
-ndvm_set_gnttab_limits(dom0_t)
+ndvm_resource_map(dom0_t)
 
 uivm_send_v4v(dom0_t)
 uivm_map_write_grant(dom0_t)
-uivm_set_gnttab_limits(dom0_t)
+uivm_resource_map(dom0_t)
 
 syncvm_map_write_grant(dom0_t)
+syncvm_resource_map(dom0_t)
 
 icavm_map_write_grant(dom0_t)
+icavm_resource_map(dom0_t)
 
 nilfvm_map_write_grant(dom0_t)
-nilfvm_set_gnttab_limits(dom0_t)
+nilfvm_resource_map(dom0_t)
 
 stubdom_copy_grant(dom0_t)
 stubdom_send_v4v(dom0_t)
 stubdom_map_write_grant(dom0_t)
-stubdom_set_gnttab_limits(dom0_t)
-
-hvm_guest_set_gnttab_limits(dom0_t)
+stubdom_resource_map(dom0_t)
 
 # access to hardware & xen
 device_admin_device(dom0_t)

--- a/policy/modules/xen/guesthvm.if
+++ b/policy/modules/xen/guesthvm.if
@@ -35,20 +35,3 @@ interface(`hvm_guest_map_write_grant',`
 
 	allow $1 hvm_guest_t:grant map_write;
 ')
-########################################
-## <summary>
-##	Allow the specified type to set hvm_guest gnttab limits.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`hvm_guest_set_gnttab_limits',`
-	gen_require(`
-		type hvm_guest_t;
-	')
-
-	allow $1 hvm_guest_t:domain2 set_gnttab_limits;
-')

--- a/policy/modules/xen/icavm.if
+++ b/policy/modules/xen/icavm.if
@@ -35,3 +35,22 @@ interface(`icavm_map_write_grant',`
 
 	allow $1 icavm_t:grant map_write;
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to access
+##	the icavm's resource map.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`icavm_resource_map',`
+	gen_require(`
+		type icavm_t;
+	')
+
+	allow $1 icavm_t:domain2 resource_map;
+')

--- a/policy/modules/xen/ndvm.if
+++ b/policy/modules/xen/ndvm.if
@@ -197,9 +197,11 @@ interface(`ndvm_copy_grant',`
 
 	allow $1 ndvm_t:grant copy;
 ')
+
 ########################################
 ## <summary>
-##	Allow the specified type to set ndvm gnttab limits.
+##	Allow the specified domain to access
+##	the NDVM's resource map.
 ## </summary>
 ## <param name="type">
 ##	<summary>
@@ -207,10 +209,10 @@ interface(`ndvm_copy_grant',`
 ##	</summary>
 ## </param>
 #
-interface(`ndvm_set_gnttab_limits',`
+interface(`ndvm_resource_map',`
 	gen_require(`
 		type ndvm_t;
 	')
 
-	allow $1 ndvm_t:domain2 set_gnttab_limits;
+	allow $1 ndvm_t:domain2 resource_map;
 ')

--- a/policy/modules/xen/nilfvm.if
+++ b/policy/modules/xen/nilfvm.if
@@ -126,9 +126,11 @@ interface(`nilfvm_copy_grant',`
 
 	allow $1 nilfvm_t:grant copy;
 ')
+
 ########################################
 ## <summary>
-##	Allow the specified type to set nilfvm gnttab limits.
+##	Allow the specified domain to access
+##	the nilfvm's resource map.
 ## </summary>
 ## <param name="type">
 ##	<summary>
@@ -136,10 +138,10 @@ interface(`nilfvm_copy_grant',`
 ##	</summary>
 ## </param>
 #
-interface(`nilfvm_set_gnttab_limits',`
+interface(`nilfvm_resource_map',`
 	gen_require(`
 		type nilfvm_t;
 	')
 
-	allow $1 nilfvm_t:domain2 set_gnttab_limits;
+	allow $1 nilfvm_t:domain2 resource_map;
 ')

--- a/policy/modules/xen/stubdom.if
+++ b/policy/modules/xen/stubdom.if
@@ -149,9 +149,11 @@ interface(`stubdom_map_write_grant',`
 
 	allow $1 stubdom_t:grant map_write;
 ')
+
 ########################################
 ## <summary>
-##	Allow the specified type to set stubdom gnttab limits.
+##	Allow the specified domain to access
+##	the stubdom's resource map.
 ## </summary>
 ## <param name="type">
 ##	<summary>
@@ -159,10 +161,10 @@ interface(`stubdom_map_write_grant',`
 ##	</summary>
 ## </param>
 #
-interface(`stubdom_set_gnttab_limits',`
+interface(`stubdom_resource_map',`
 	gen_require(`
 		type stubdom_t;
 	')
 
-	allow $1 stubdom_t:domain2 set_gnttab_limits;
+	allow $1 stubdom_t:domain2 resource_map;
 ')

--- a/policy/modules/xen/syncvm.if
+++ b/policy/modules/xen/syncvm.if
@@ -53,3 +53,22 @@ interface(`syncvm_map_write_grant',`
 
 	allow $1 syncvm_t:grant map_write;
 ')
+
+########################################
+## <summary>
+##	Allow the specified domain to access
+##	the SyncVM's resource map.
+## </summary>
+## <param name="type">
+##	<summary>
+##	Type of the domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`syncvm_resource_map',`
+	gen_require(`
+		type syncvm_t;
+	')
+
+	allow $1 syncvm_t:domain2 resource_map;
+')

--- a/policy/modules/xen/uivm.if
+++ b/policy/modules/xen/uivm.if
@@ -55,9 +55,11 @@ interface(`uivm_map_write_grant',`
 
 	allow $1 uivm_t:grant map_write;
 ')
+
 ########################################
 ## <summary>
-##	Allow the specified type to set uivm gnttab limits.
+##	Allow the specified domain to access
+##	the UIVM's resource map.
 ## </summary>
 ## <param name="type">
 ##	<summary>
@@ -65,10 +67,10 @@ interface(`uivm_map_write_grant',`
 ##	</summary>
 ## </param>
 #
-interface(`uivm_set_gnttab_limits',`
+interface(`uivm_resource_map',`
 	gen_require(`
 		type uivm_t;
 	')
 
-	allow $1 uivm_t:domain2 set_gnttab_limits;
+	allow $1 uivm_t:domain2 resource_map;
 ')

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -44,7 +44,7 @@ interface(`xen_domain_type',`
 				setaffinity getaffinity settime
 				setdomainhandle shutdown set_misc_info trigger};
 	#allow dom0_type $1:domain2 {setcorespersocket};
-	allow dom0_type $1:domain2 {setscheduler set_cpuid set_as_target set_max_evtchn settsc};
+	allow dom0_type $1:domain2 {setscheduler set_cpuid set_as_target settsc};
 			
 	allow dom0_type $1:shadow {enable};
 	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op stat };


### PR DESCRIPTION
- add get_cpu_policy
- remove set_max_evtchn and set_gnttab_limits
- grant dom0 access to resource_map of service VMs
- add argo definitions to match xen flask

OXT-1550
OXT-1563

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>