### PR TITLE
flask: Let UIVM run as a PVH guest

### DIFF
--- a/policy/modules/xen/uivm.te
+++ b/policy/modules/xen/uivm.te
@@ -26,6 +26,7 @@ policy_module(uivm, 0.2)
 type uivm_t;
 xen_domain_type(uivm_t)
 xen_pv_type(uivm_t)
+xen_hvm_type(uivm_t)
 
 type uivm-dom0_evchn_t;
 xen_event_type(uivm-dom0_evchn_t)
@@ -45,5 +46,6 @@ ndvm_send_argo(uivm_t)
 iomem_map_read_mmu(uivm_t)
 xen_write_console(uivm_t)
 dom0_copy_grant(uivm_t)
+dom0_ioemu(uivm_t)
 argo_register_any_source(uivm_t)
 argo_enable(uivm_t)


### PR DESCRIPTION
UIVM needs to be a HVM & PV to run as a PVH guest, so add the additional
xen_hvm_type.

The surfman/drm-plugin graphic stack needs to change the caching
attributes of the framebuffer region. This is done through
xc_domain_pin_memory_cacheattr which requires the dm permission
(dom0_ioemu).

This is only applied to uivm_t for now as xenfb2 is not used or
conveniently usable in a regular PVH guest.

Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>

Squash the two commits since they are needed together to have a
functional PVH uivm.

Drop hvm_guest_map_write_grant(uivm_t) since it doesn't seem necessary
in my testing.

OXT-1647

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>