### PR TITLE
Move resource_map into xen_domain_type

### DIFF
--- a/policy/modules/xen/dom0.te
+++ b/policy/modules/xen/dom0.te
@@ -51,7 +51,6 @@ allow dom0_t evchn0-0_t:event send;
 
 allow dom0_t iomem_t:resource setup;
 allow dom0_t stubdom_t:domain2 make_priv_for;
-allow dom0_t hvm_guest_t:domain2 resource_map;
 
 allow dom0_t xen_t:resource setup;
 allow dom0_t xen_t:xen mca_op;
@@ -69,25 +68,20 @@ ndvm_manage_resource(dom0_t)
 ndvm_send_argo(dom0_t)
 ndvm_use(dom0_t)
 ndvm_map_write_grant(dom0_t)
-ndvm_resource_map(dom0_t)
 
 uivm_send_argo(dom0_t)
 uivm_map_write_grant(dom0_t)
-uivm_resource_map(dom0_t)
 
 syncvm_map_write_grant(dom0_t)
-syncvm_resource_map(dom0_t)
 
 icavm_map_write_grant(dom0_t)
 icavm_resource_map(dom0_t)
 
 nilfvm_map_write_grant(dom0_t)
-nilfvm_resource_map(dom0_t)
 
 stubdom_copy_grant(dom0_t)
 stubdom_send_argo(dom0_t)
 stubdom_map_write_grant(dom0_t)
-stubdom_resource_map(dom0_t)
 
 # access to hardware & xen
 device_admin_device(dom0_t)

--- a/policy/modules/xen/ndvm.if
+++ b/policy/modules/xen/ndvm.if
@@ -217,22 +217,3 @@ interface(`ndvm_copy_grant',`
 
 	allow $1 ndvm_t:grant copy;
 ')
-
-########################################
-## <summary>
-##	Allow the specified domain to access
-##	the NDVM's resource map.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`ndvm_resource_map',`
-	gen_require(`
-		type ndvm_t;
-	')
-
-	allow $1 ndvm_t:domain2 resource_map;
-')

--- a/policy/modules/xen/nilfvm.if
+++ b/policy/modules/xen/nilfvm.if
@@ -126,22 +126,3 @@ interface(`nilfvm_copy_grant',`
 
 	allow $1 nilfvm_t:grant copy;
 ')
-
-########################################
-## <summary>
-##	Allow the specified domain to access
-##	the nilfvm's resource map.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`nilfvm_resource_map',`
-	gen_require(`
-		type nilfvm_t;
-	')
-
-	allow $1 nilfvm_t:domain2 resource_map;
-')

--- a/policy/modules/xen/stubdom.if
+++ b/policy/modules/xen/stubdom.if
@@ -169,22 +169,3 @@ interface(`stubdom_map_write_grant',`
 
 	allow $1 stubdom_t:grant map_write;
 ')
-
-########################################
-## <summary>
-##	Allow the specified domain to access
-##	the stubdom's resource map.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`stubdom_resource_map',`
-	gen_require(`
-		type stubdom_t;
-	')
-
-	allow $1 stubdom_t:domain2 resource_map;
-')

--- a/policy/modules/xen/syncvm.if
+++ b/policy/modules/xen/syncvm.if
@@ -53,22 +53,3 @@ interface(`syncvm_map_write_grant',`
 
 	allow $1 syncvm_t:grant map_write;
 ')
-
-########################################
-## <summary>
-##	Allow the specified domain to access
-##	the SyncVM's resource map.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`syncvm_resource_map',`
-	gen_require(`
-		type syncvm_t;
-	')
-
-	allow $1 syncvm_t:domain2 resource_map;
-')

--- a/policy/modules/xen/uivm.if
+++ b/policy/modules/xen/uivm.if
@@ -75,22 +75,3 @@ interface(`uivm_map_write_grant',`
 
 	allow $1 uivm_t:grant map_write;
 ')
-
-########################################
-## <summary>
-##	Allow the specified domain to access
-##	the UIVM's resource map.
-## </summary>
-## <param name="type">
-##	<summary>
-##	Type of the domain allowed access.
-##	</summary>
-## </param>
-#
-interface(`uivm_resource_map',`
-	gen_require(`
-		type uivm_t;
-	')
-
-	allow $1 uivm_t:domain2 resource_map;
-')

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -44,8 +44,9 @@ interface(`xen_domain_type',`
 				setaffinity getaffinity settime
 				setdomainhandle shutdown set_misc_info trigger};
 	#allow dom0_type $1:domain2 {setcorespersocket};
-	allow dom0_type $1:domain2 {setscheduler set_cpuid set_as_target settsc};
-			
+	allow dom0_type $1:domain2 { resource_map setscheduler set_cpuid
+				set_as_target settsc};
+
 	allow dom0_type $1:shadow {enable};
 	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op stat };
 	allow dom0_type $1:resource { add remove };


### PR DESCRIPTION
Dom0 needs resource_map for every domain, so just put it into the
xen_domain_type definition.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>