### PR TITLE
syncvm: Allow running as PVH

### DIFF
--- a/policy/modules/xen/syncvm.te
+++ b/policy/modules/xen/syncvm.te
@@ -26,6 +26,7 @@ policy_module(syncvm, 0.2)
 type syncvm_t;
 xen_domain_type(syncvm_t)
 xen_pv_type(syncvm_t)
+xen_hvm_type(syncvm_t)
 
 type syncvm-dom0_evchn_t;
 xen_event_type(syncvm-dom0_evchn_t)


### PR DESCRIPTION
Use xen_hvm_type(syncvm) so the syncvm can be run as a PVH domain to
avoid some spectre and metldown issues.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

Needed to boot in PVH mode with https://github.com/OpenXT/xenclient-oe/pull/1420