### PR TITLE
Add usbvm_t, dm_usbvm_t & dm_ndvm_t typealias

### DIFF
--- a/policy/modules/xen/ndvm.te
+++ b/policy/modules/xen/ndvm.te
@@ -24,6 +24,7 @@ policy_module(ndvm, 0.2)
 #
 
 type ndvm_t;
+typealias ndvm_t alias { usbvm_t };
 xen_domain_type(ndvm_t)
 xen_pv_type(ndvm_t)
 xen_hvm_type(ndvm_t)

--- a/policy/modules/xen/stubdom.te
+++ b/policy/modules/xen/stubdom.te
@@ -24,6 +24,7 @@ policy_module(stubdom, 0.2)
 #
 
 type stubdom_t;
+typealias stubdom_t alias { dm_ndvm_t dm_usbvm_t };
 xen_domain_type(stubdom_t)
 xen_pv_type(stubdom_t)
 


### PR DESCRIPTION
ndvm_t can serve as the usbvm's type since it can access PCI devices and
do PV comms with guests.  Add a typealias so it can be re-used while a
dedicated type is not available.

Also add dm_ndvm_t to differentiate.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>