### PR TITLE
[hvm] Allow hvm_guest_t hvmctl to itself

### DIFF
--- a/policy/modules/xen/guesthvm.te
+++ b/policy/modules/xen/guesthvm.te
@@ -27,6 +27,8 @@ type hvm_guest_t;
 xen_domain_type(hvm_guest_t)
 xen_hvm_type(hvm_guest_t)
 
+allow hvm_guest_t self:hvm { hvmctl };
+
 #types for event channel between hvm_guest and dom0
 type hvm_guest-dom0_evchn_t;
 xen_event_type(hvm_guest-dom0_evchn_t)


### PR DESCRIPTION
    This suppresses log spam when the guest crashes or has difficulty
    shutting down. Other guest types already have this rule in place,
    add it to hvm guests as well.
    
    Signed-off-by: Richard Turner <turnerr@ainfosec.com>
    Signed-off-by: Nicholas Tsirakis <niko.tsirakis@gmail.com>
