### PR TITLE
Include policy changes from Xen 4.18

### DIFF
--- a/policy/flask/access_vectors
+++ b/policy/flask/access_vectors
@@ -99,6 +99,8 @@ class xen2
     livepatch_op
 # XEN_SYSCTL_coverage_op
     coverage_op
+# XENPF_get_dom0_console
+    get_dom0_console
 }
 
 # Classes domain and domain2 consist of operations that a domain performs on
@@ -249,6 +251,8 @@ class domain2
     resource_map
 # XEN_DOMCTL_get_cpu_policy
     get_cpu_policy
+# XEN_DOMCTL_vuart_op
+    vuart_op
 }
 
 # Similar to class domain, but primarily contains domctls related to HVM domains

--- a/policy/modules/xen/dom0.te
+++ b/policy/modules/xen/dom0.te
@@ -54,6 +54,7 @@ allow dom0_t stubdom_t:domain2 make_priv_for;
 allow dom0_t xen_t:resource setup;
 allow dom0_t xen_t:xen mca_op;
 allow dom0_t xen_t:xen2 get_cpu_featureset;
+allow dom0_t xen_t:xen2 get_dom0_console;
 
 domio_map_rw_mmu(dom0_t)
 

--- a/policy/modules/xen/xen.if
+++ b/policy/modules/xen/xen.if
@@ -58,7 +58,7 @@ interface(`xen_domain_type',`
 				getpagingmempool setpagingmempool };
 	#allow dom0_type $1:domain2 {setcorespersocket};
 	allow dom0_type $1:domain2 { resource_map setscheduler set_cpu_policy
-				set_as_target settsc};
+				set_as_target settsc vuart_op };
 
 	allow dom0_type $1:shadow {enable};
 	allow dom0_type $1:mmu {map_read map_write memorymap adjust pinpage physmap mmuext_op stat };


### PR DESCRIPTION
These changes sync the xsm-policy repo with the latest changes on 4.18. These are needed in order to allow flask=enforcing configuration.